### PR TITLE
Removed the h2 from Ask NYPL from this release.

### DIFF
--- a/public/views/division.html
+++ b/public/views/division.html
@@ -307,9 +307,6 @@
     <nypl-fundraising fundraising="division.fundraising" category="Locations"></nypl-fundraising><!--
 
     --><div class="askNYPL grid__item one-whole lap-and-up-one-half " id="ask-nypl">
-      <h2 class="visuallyHidden">
-        <span id="ask-nypl-title">Ask NYPL</span>
-      </h2>
       <ul>
         <li class="asknum icon-phone">
           <a href="tel:917-275-6975">917-ASK-NYPL</a>

--- a/public/views/location.html
+++ b/public/views/location.html
@@ -374,9 +374,6 @@
     <nypl-fundraising fundraising="location.fundraising" category="Locations"></nypl-fundraising><!--
 
     --><div class="askNYPL grid__item one-whole lap-and-up-one-half " id="ask-nypl">
-      <h2 class="visuallyHidden">
-        <span id="ask-nypl-title">Ask NYPL</span>
-      </h2>
       <ul>
         <li class="asknum icon-phone">
           <a href="tel:917-275-6975">917-ASK-NYPL</a>


### PR DESCRIPTION
Based on what Willa suggested today (May 31). The `<h2>` of `ASK NYPL` that part of the fixes for the headings for the coming  release should be visible. That will change the layout and I think will be better to have design and content teams to confirm it. And it will be carried over to the next sprint. Thus, the PR removes this particular change for now, back to the previous stage, and the requited fix will be update in the next sprint.