### PR TITLE
Added aria-label to learn more button for about sections.

### DIFF
--- a/public/views/division.html
+++ b/public/views/division.html
@@ -145,7 +145,7 @@
         <div class="text--right">
           <a class="read-more collection-more" data-ng-href="{{division._links.self.about}}"
             analytics-on="click" analytics-category="Locations"
-            analytics-event="Click" analytics-label="Learn More">
+            analytics-event="Click" analytics-label="Learn More" aria-label="Learn more about this division">
             Learn more</a>
         </div>
       </div><!--

--- a/public/views/location.html
+++ b/public/views/location.html
@@ -268,7 +268,7 @@
             <div class="text--right">
               <a class="read-more" data-ng-href="{{location._links.self.about}}"
                 analytics-on="click" analytics-category="Locations"
-                analytics-event="Click" analytics-label="Learn More">
+                analytics-event="Click" analytics-label="Learn More" aria-label="Learn more about this location">
                 Learn more
               </a>
             </div>


### PR DESCRIPTION
This PR adds aria label attributes to GRD and Location pages to fix the issue of www-200, the learn button for `About` section is not descriptive.

https://jira.nypl.org/browse/WWW-200

This PR, once approved, will be merged only after all the PRs for sprint 11, including the documentation PR, are merged as it fixes the issue of sprint 12.