### PR TITLE
Add aria label to see more button on about section

### DIFF
--- a/public/views/division.html
+++ b/public/views/division.html
@@ -145,7 +145,7 @@
         <div class="text--right">
           <a class="read-more collection-more" data-ng-href="{{division._links.self.about}}"
             analytics-on="click" analytics-category="Locations"
-            analytics-event="Click" analytics-label="Learn More">
+            analytics-event="Click" analytics-label="Learn More" aria-label="Learn more about this division">
             Learn more</a>
         </div>
       </div><!--

--- a/public/views/location.html
+++ b/public/views/location.html
@@ -268,7 +268,7 @@
             <div class="text--right">
               <a class="read-more" data-ng-href="{{location._links.self.about}}"
                 analytics-on="click" analytics-category="Locations"
-                analytics-event="Click" analytics-label="Learn More">
+                analytics-event="Click" analytics-label="Learn More" aria-label="Learn more about this location">
                 Learn more
               </a>
             </div>


### PR DESCRIPTION
**This PR needs wait to be merged after the release for sprint 11 is deployed**

I am sorry I wrongly merged the previous same PR that shouldn't be merged. So I had to reverse it back and created this PR again.

This is for fixing https://jira.nypl.org/browse/WWW-200

The PR adds `aria-label` to `Learn More` button to make more descriptive contents for screen readers.