### PR TITLE
Header skip nav

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,5 @@ test/coverage/*
 Gemfile.lock
 public/bower_components
 package-lock.json
+
+.elasticbeanstalk/*

--- a/views/index.erb
+++ b/views/index.erb
@@ -50,13 +50,6 @@
       <div class="browser-upgrade">You are using an <strong>outdated</strong> browser. Please <a href="http://browsehappy.com/?locale=en">upgrade your browser</a> to improve your experience.</div>
     <![endif]-->
 
-    <div class="visuallyhidden">
-        <div>
-            <a href="http://lblpac.nypl.org/klasweb/" title="Click to search the Andrew Heiskell Braille and Talking Book Library">Click to search the Andrew Heiskell Braille and Talking Book Library</a>
-            <a href="#main-content">Skip Navigation</a>
-        </div>
-    </div>
-
     <!-- Header -->
     <div id="Header-Placeholder">
         <style>
@@ -69,7 +62,7 @@
                 }
             }
         </style>
-        <script type="text/javascript" src="https://<%= settings.refinery_api %>header.nypl.org/dgx-header.min.js" async></script>
+        <script type="text/javascript" src="https://<%= settings.refinery_api %>header.nypl.org/dgx-header.min.js?skipNav=main-content" async></script>
     </div>
 
     <main class="wrapper" id="main-content">


### PR DESCRIPTION
Removing existing skip nav and using the skip nav from the global header. Fixes https://jira.nypl.org/browse/WWW-201

Check https://dev-www.nypl.org/locations/ . Even the 404 page is fine if there's no data. You should still be able to tab through to get to it.