### PR TITLE
SEB-1707 Update CrowdStrike version

### DIFF
--- a/.ebextensions/071_falcon_crowdstrike.config
+++ b/.ebextensions/071_falcon_crowdstrike.config
@@ -9,7 +9,8 @@ files:
       cd /home/ec2-user
       yum -q list installed falcon-sensor &> /dev/null && isInstalled="yes" || isInstalled="no"
       if [ $isInstalled == "no" ]; then
-        wget http://yumrepo.aws.nypl.org/nypl-yum/rpm/x86_64/falcon-sensor-3.8.0-3902.amzn1.x86_64.rpm
-        yum -y install /home/ec2-user/falcon-sensor-3.8.0-3902.amzn1.x86_64.rpm
+        wget https://s3.amazonaws.com/nypl-rpms/falcon-sensor-5.29.0-9403.amzn1.x86_64.rpm
+        yum -y install /home/ec2-user/falcon-sensor-5.29.0-9403.amzn1.x86_64.rpm
+        /opt/CrowdStrike/falconctl -s --cid=2F323D2F1EF049D0BCE9A15DDC55D946-19
       fi
     encoding: plain

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,3 +1,6 @@
+## Tag v1.12.3
+* Updating Falcon Crowdstrike sensor to 5.29.
+
 ## Tag v1.12.2
 * Removed Tumblr icon link in footer.
 * Added system-font-css.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "locations",
-  "version": "1.12.2",
+  "version": "1.12.3",
   "dependencies": {
     "protractor": "1.8.0",
     "karma-jasmine": "0.3.5",


### PR DESCRIPTION
The previous CrowdStrike version is deprecated and will no longer be supported by Falcon Sensor. The new version will include Falcon auto-update version remotely on the instances. This code change will cover the newly rebuilt Elastic Beanstalk instances via autoscaling.